### PR TITLE
Conflict Exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,9 @@
 {
-    "name": "nfrastructure/php-http-exceptions",
+    "name": "nfra/php-http-exceptions",
     "description": "A Suite of php exceptions which map nicely to HTTP Error Statues",
     "type": "library",
+    "version": "1.1.0",
     "config": {
-        "preferred-install": {
-            "nfrastructure": "source,",
-            "*": "dist"
-        },
         "optimize-autoloader": true
     },
     "support": {

--- a/src/DuplicateException.php
+++ b/src/DuplicateException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Nfra\Exceptions;
+
+use Lukasoppermann\Httpstatus\Httpstatuscodes;
+
+class DuplicateException extends \DomainException
+{
+    public function __construct( $message = null)
+    {
+        $message = null === $message
+            ? StaticStatusFactory::factory()->getReasonPhrase(Httpstatuscodes::HTTP_CONFLICT)
+            : $message;
+
+        parent::__construct($message, Httpstatuscodes::HTTP_CONFLICT);
+    }
+}

--- a/tests/DuplicateExceptionTest.php
+++ b/tests/DuplicateExceptionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Nfra\ExceptionsTest;
+
+use Lukasoppermann\Httpstatus\Httpstatuscodes;
+use Nfra\Exceptions\DuplicateException;
+use Nfra\Exceptions\StaticStatusFactory;
+use PHPUnit\Framework\TestCase;
+
+class DuplicateExceptionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testItShouldSetCorrectCodeWithNoMessage()
+    {
+        $this->expectException(DuplicateException::class);
+        $this->expectExceptionMessage(
+            StaticStatusFactory::factory()->getReasonPhrase(Httpstatuscodes::HTTP_CONFLICT)
+        );
+        $this->expectExceptionCode(Httpstatuscodes::HTTP_CONFLICT);
+
+        throw new DuplicateException();
+    }
+
+    /**
+     * @test
+     */
+    public function testItShouldSetCorrectCodeWithMessage()
+    {
+        $this->expectException(DuplicateException::class);
+        $this->expectExceptionMessage('Foo not found');
+        $this->expectExceptionCode(Httpstatuscodes::HTTP_CONFLICT);
+
+        throw new DuplicateException('Foo not found');
+    }
+}


### PR DESCRIPTION
When a duplicate entity is posted, it is best to raise a 409
response code. This tells the consumer that they are trying
to add or update matches another entity in the system.

I also adjusted the namespace in composer to match the approved style guide